### PR TITLE
Fix bugs in find command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "{0,choice,1#1 person|1<{0} persons} listed";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND =
+            "{0,choice,1#1 person|1<{0} persons} listed using the ''{1}'' command.";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_TIMESLOT_CONFLICT = "This time slot conflicts with another existing time slot!";

--- a/src/main/java/seedu/address/logic/commands/FilterTimeslotCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterTimeslotCommand.java
@@ -35,8 +35,8 @@ public class FilterTimeslotCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         String filterDescription = predicate.getFilterDescription();
-        String resultMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
-                model.getFilteredPersonList().size())
+        String resultMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND,
+                model.getFilteredPersonList().size(), "filtertimeslot")
                 + " " + filterDescription;
         return new CommandResult(resultMessage);
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -33,7 +33,11 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                MessageFormat.format(
+                        Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND,
+                        model.getFilteredPersonList().size(),
+                        "find" // or "findtimeslot" depending on the command
+                ));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTagCommand.java
@@ -33,8 +33,8 @@ public class FindTagCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         String keywords = String.join(", ", predicate.getKeywords());
-        String resultMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
-                model.getFilteredPersonList().size())
+        String resultMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND,
+                model.getFilteredPersonList().size(), "findtag")
                 + " with tag(s): [" + keywords + "]";
         return new CommandResult(resultMessage);
     }

--- a/src/main/java/seedu/address/logic/commands/FindTimeslotCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTimeslotCommand.java
@@ -34,8 +34,8 @@ public class FindTimeslotCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         String keywords = String.join(", ", predicate.getKeywords());
-        String resultMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
-                model.getFilteredPersonList().size())
+        String resultMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND,
+                model.getFilteredPersonList().size(), "findtimeslot")
                 + " with timeslot starting on/at: [" + keywords + "]";
         return new CommandResult(resultMessage);
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -26,6 +26,11 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
+        if (trimmedArgs.startsWith("timeslot")) {
+            throw new ParseException(
+                    "Did you mean: findtimeslot " + trimmedArgs.substring("timeslot".length()).trim() + "?");
+        }
+
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,6 +168,7 @@ public class ParserUtil {
                 throw new ParseException("Date should be in YYYY-MM-DD format.", e);
             }
         }
+
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FilterTimeslotCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterTimeslotCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.text.MessageFormat;
@@ -59,7 +59,8 @@ public class FilterTimeslotCommandTest {
         TimeslotRangePredicate predicate = new TimeslotRangePredicate(
                 Optional.of(LocalDate.of(2030, 1, 1)), Optional.empty(),
                 Optional.empty(), Optional.empty());
-        String expectedMessage = MessageFormat.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
+        String expectedMessage = MessageFormat.format(
+                MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "filtertimeslot")
                 + " " + predicate.getFilterDescription();
         FilterTimeslotCommand command = new FilterTimeslotCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
@@ -59,7 +59,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = MessageFormat.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = MessageFormat.format(
+                MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "find");
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -69,7 +70,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = MessageFormat.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = MessageFormat.format(
+                MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 3, "find");
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -79,7 +81,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_multiplePartialKeywords_multiplePersonsFound() {
-        String expectedMessage = MessageFormat.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = MessageFormat.format(
+                MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 3, "find");
         NameContainsKeywordsPredicate predicate = preparePredicate("urz Ell Kun");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -89,7 +92,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_wrongKeyword_noPersonsFound() {
-        String expectedMessage = MessageFormat.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = MessageFormat.format(
+                MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "find");
         NameContainsKeywordsPredicate predicate = preparePredicate("dominic");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -99,7 +103,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_oneKeyword_multiplePersonsFound() {
-        String expectedMessage = MessageFormat.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        String expectedMessage = MessageFormat.format(
+                MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 2, "find");
         NameContainsKeywordsPredicate predicate = preparePredicate("Meier");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/address/logic/commands/FindTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTagCommandTest.java
@@ -74,7 +74,8 @@ public class FindTagCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0) + " with tag(s): []";
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "findtag") + " with tag(s): []";
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.emptyList());
         FindTagCommand command = new FindTagCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -93,8 +94,8 @@ public class FindTagCommandTest {
         expectedModel.updateFilteredPersonList(predicate);
 
         String expectedMessage = MessageFormat.format(
-                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
-                expectedModel.getFilteredPersonList().size());
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND,
+                expectedModel.getFilteredPersonList().size(), "findtag");
         expectedMessage += " with tag(s): " + keywords;
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         // Ensure filtered list matches expected count
@@ -105,7 +106,8 @@ public class FindTagCommandTest {
     public void execute_singleKeyword_findsPersons() {
         // We use TypicalPersons data here. ALICE, BENSON, and DANIEL have the 'friends' tag.
         String keywords = "friends";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 3)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 3, "findtag")
                 + " with tag(s): [" + keywords + "]";
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singletonList(keywords));
         FindTagCommand command = new FindTagCommand(predicate);
@@ -122,7 +124,8 @@ public class FindTagCommandTest {
         // BENSON has 'owesMoney', ALICE and DANIEL have 'friends'.
         // The predicate finds contacts that match *any* keyword.
         String keywords = "owesMoney, friends";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 3)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 3, "findtag")
                 + " with tag(s): [" + keywords + "]";
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(
                 Arrays.asList("owesMoney", "friends"));
@@ -137,7 +140,8 @@ public class FindTagCommandTest {
     @Test
     public void execute_noMatchingKeywords_noPersonFound() {
         String keywords = "nonexistent, tag";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "findtag")
                 + " with tag(s): [" + keywords + "]";
         TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Arrays.asList("nonexistent", "tag"));
         FindTagCommand command = new FindTagCommand(predicate);

--- a/src/test/java/seedu/address/logic/commands/FindTimeslotCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTimeslotCommandTest.java
@@ -56,7 +56,8 @@ public class FindTimeslotCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String keywords = "";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "findtimeslot")
                 + " with timeslot starting on/at: [" + keywords + "]";
         TimeslotStartTimeContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindTimeslotCommand command = new FindTimeslotCommand(predicate);
@@ -72,7 +73,8 @@ public class FindTimeslotCommandTest {
 
         // Example: Search for a specific date that exists in test data
         String keywords = "2025-10-12";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 1, "findtimeslot")
                 + " with timeslot starting on/at: [" + keywords + "]";
         TimeslotStartTimeContainsKeywordsPredicate predicate = preparePredicate("2025-10-12");
         FindTimeslotCommand command = new FindTimeslotCommand(predicate);
@@ -87,7 +89,8 @@ public class FindTimeslotCommandTest {
     public void execute_timeKeyword_personsFound() {
         // Test searching by time format (HHmm)
         String keywords = "0900";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "findtimeslot")
                 + " with timeslot starting on/at: [" + keywords + "]";
         TimeslotStartTimeContainsKeywordsPredicate predicate = preparePredicate("0900");
         FindTimeslotCommand command = new FindTimeslotCommand(predicate);
@@ -99,7 +102,8 @@ public class FindTimeslotCommandTest {
     public void execute_mixedDateAndTimeKeywords_personsFound() {
         // Test searching with both date and time keywords
         String keywords = "2025-10-12, 0900, 1400";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "findtimeslot")
                 + " with timeslot starting on/at: [" + keywords + "]";
         TimeslotStartTimeContainsKeywordsPredicate predicate = preparePredicate("2025-10-12", "0900", "1400");
         FindTimeslotCommand command = new FindTimeslotCommand(predicate);
@@ -110,7 +114,8 @@ public class FindTimeslotCommandTest {
     @Test
     public void execute_noMatchingKeywords_noPersonFound() {
         String keywords = "9999-12-31";
-        String expectedMessage = MessageFormat.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0)
+        String expectedMessage = MessageFormat.format(
+                Messages.MESSAGE_PERSONS_LISTED_OVERVIEW_WITH_COMMAND, 0, "findtimeslot")
                 + " with timeslot starting on/at: [" + keywords + "]";
         TimeslotStartTimeContainsKeywordsPredicate predicate = preparePredicate("9999-12-31");
         FindTimeslotCommand command = new FindTimeslotCommand(predicate);

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -36,4 +36,5 @@ public class CommandParserTestUtil {
             assertEquals(expectedMessage, pe.getMessage());
         }
     }
+
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -37,4 +37,13 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_findWithTimeslotKeyword_showsWarningMessage() {
+        FindCommandParser parser = new FindCommandParser();
+        String userInput = "timeslot 2025-10-22";
+        String expectedMessage = "Did you mean: findtimeslot 2025-10-22?";
+
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/FindTimeslotCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTimeslotCommandParserTest.java
@@ -59,5 +59,6 @@ public class FindTimeslotCommandParserTest {
         assertParseFailure(parser, "09:00",
                 String.format(FindTimeslotCommandParser.MESSAGE_INVALID_KEYWORD, "09:00"));
     }
+
 }
 


### PR DESCRIPTION
Solve issue #204 by including command type in success message for FindCommand, FindTimeSlotCommand, FilterTimeSlotCommand and FindTagCommand.

In addition, add new ParseException message specific to the input "find timeslot".